### PR TITLE
Add common dependencies and update Node-Red Production port

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,20 @@ Once the container is started, you can access the NodeRed environment on `localH
 To start the environment in development mode run the following command:
 
 ```bash
-docker-compose up -d
+docker-compose up -d --build
 ```
 
 This command will start the NodeRed and Mosquitto containers in detached mode, allowing it to run in the background.
 
 #### Production
-To start the enviroment in production mode run the following command:
+To start the enviroment in production mode run the following command, where XXXX is the desired port to access node-red in production (this assumes it is being run in a linux environment):
+##### Linux
 ```bash
-docker compose -f "docker-compose.yml" up -d
+NODE_RED_PORT=XXXX docker-compose -f "docker-compose.yml" up -d --build
+```
+##### Windows
+```bash
+$env:NODE_RED_PORT="XXXX"; docker-compose up -d
 ```
 
 This command will start only the NodeRed container in detached mode.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,14 +8,12 @@ services:
     container_name: template-nodered-app-nodered
     build: ./node-red
     ports:
-      - 1880:1880
+      - "${NODE_RED_PORT:-1880}:1880"
     volumes:
       - node-red-data:/data
       - ./node-red/settings.js:/data/settings.js
     networks:
       - template-nodered-app-net
-    environment:
-      - TEST="Hello World"
     env_file: "prod.env"
 
 volumes:

--- a/node-red/Dockerfile
+++ b/node-red/Dockerfile
@@ -2,3 +2,6 @@ FROM nodered/node-red:latest
 
 # Install pallette dependencies
 RUN npm install @flowfuse/node-red-dashboard
+RUN npm install node-red-contrib-mssql-plus
+RUN npm install @nhimm/node-red-contrib-data-forge
+RUN npm install node-red-contrib-filesystem

--- a/prod.env
+++ b/prod.env
@@ -1,2 +1,10 @@
 # API Keys
 SERVICE_APIKEY = your-api-key
+
+# GP-SQL-DB
+DB_SERVER = cphSQL.cphnet.us\GP
+DB_PORT = 1433
+DB_DB_NHI = NHI
+DB_DB_TERRE = PHX
+DB_USER = --Create a user in SQL Server
+DB_PASSWORD = --Create a password in SQL Server


### PR DESCRIPTION
- Add common dependencies in the Node-Red Pallette
  - node-red-contrib-mssql-plus - for accessing GP database
  - @nhimm/node-red-contrib-data-forge - for manipulating datasets
  - node-red-contrib-filesystem - for filesystem manipulation
- Node-Red port is now assigned in the container start command, making it simpler to manage multiple Node-Red instances on a single VM by removing the need to hard-code port mappings